### PR TITLE
Development mailserver added

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -100,6 +100,11 @@ MARIADB_PORT=3306
 MARIADB_ROOT_PASSWORD=root
 MARIADB_ENTRYPOINT_INITDB=./mariadb/docker-entrypoint-initdb.d
 
+### SMTP ######################################################################
+
+SMTP_INCOMING_PORT=1025
+SMTP_WEBCLIENT_PORT=1080
+
 ### ELASTICSEARCH ######################################################################
 
 ELASTICSEARCH_HOST_HTTP_PORT=9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -93,6 +93,7 @@ services:
       - "${NGINX_HOST_HTTPS_PORT}:443"
     depends_on:
       - php-fpm
+      - smtp
     networks:
       - frontend
       - backend
@@ -114,6 +115,7 @@ services:
       - "${APACHE2_HOST_HTTPS_PORT}:443"
     depends_on:
       - php-fpm
+      - smtp
     networks:
       - frontend
       - backend
@@ -196,6 +198,17 @@ services:
       - frontend
       - backend
 
+### Smtp ######################################################
+
+  smtp:
+    build: ./mail
+    ports:
+      - "1025:1025"
+      - "1080:1080"
+    networks:
+      - frontend
+      - backend
+
 ### Networks Setup ############################################
 
 networks:
@@ -215,3 +228,7 @@ volumes:
     driver: "local"
   elasticsearch-plugins:
     driver: "local"
+  maildata:
+    driver: local
+  mailstate:
+    driver: local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,8 +203,8 @@ services:
   smtp:
     build: ./mail
     ports:
-      - "1025:1025"
-      - "1080:1080"
+      - "${SMTP_INCOMING_PORT}:1025"
+      - "${SMTP_WEBCLIENT_PORT}:1080"
     networks:
       - frontend
       - backend

--- a/mail/Dockerfile
+++ b/mail/Dockerfile
@@ -1,0 +1,5 @@
+FROM schickling/mailcatcher:latest
+
+MAINTAINER Spring Digital <development@springdigital.nl>
+
+EXPOSE 1025 1080

--- a/tools/brew.sh
+++ b/tools/brew.sh
@@ -3,7 +3,7 @@
 if test ! $(which brew); then
     echo "Installing homebrew"
 
-    ruby "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 fi
 
 echo -e "\n\nInstalling homebrew packages..."


### PR DESCRIPTION
Added a docker configuration for a mailcatcher installation
Also fixed the brew tool install

After running the `docker-compose up -d nginx [mariadb]` mailcatcher is exposed on the following ports:

- 1025 -> SMTP (no TLS, no SSL, no authentication)
- 1080 -> HTTP client

Mailcatcher functions as a mailtrap server, i.e. it will not forward anything, but catch all mails received.